### PR TITLE
AST-14749 - Visual Studio | Attack Vector Links Not Working

### DIFF
--- a/ast-visual-studio-extension/CxExtension/Utils/SolutionExplorerUtils.cs
+++ b/ast-visual-studio-extension/CxExtension/Utils/SolutionExplorerUtils.cs
@@ -88,7 +88,9 @@ namespace ast_visual_studio_extension.CxExtension.Utils
 
             foreach (Project project in projects)
             {
-                if (string.IsNullOrEmpty(project.FullName)) continue;
+                bool projectIsUnloadedInSolution = string.Compare(EnvDTE.Constants.vsProjectKindUnmodeled, project.Kind, System.StringComparison.OrdinalIgnoreCase) == 0;
+                
+                if (projectIsUnloadedInSolution || string.IsNullOrEmpty(project.FullName)) continue;
 
                 FileInfo projectFileInfo = new FileInfo(project.FullName);
                 string projectPath = Directory.GetParent(projectFileInfo.Directory.FullName).FullName;


### PR DESCRIPTION
- Avoid Visual Studio to crash when trying to get files from an unloaded project. Skip unloaded projects in solution.