### PR TITLE
Add CLI/Wrapper logs print to file (AST-81186)

### DIFF
--- a/ast-visual-studio-extension/CxExtension/CxWindowPackage.cs
+++ b/ast-visual-studio-extension/CxExtension/CxWindowPackage.cs
@@ -119,10 +119,19 @@ namespace ast_visual_studio_extension.CxExtension
                 {
                     throw new FileNotFoundException("log4net.config not found in expected locations.");
                 }
-                var logRepository = LogManager.GetRepository();
-                XmlConfigurator.Configure(logRepository, new FileInfo(log4netConfigPath));
 
-                var appender = ((Hierarchy)logRepository).Root.Appenders[0];
+                var logRepository = LogManager.GetRepository();
+                // Configure with ConfigureAndWatch to enable dynamic configuration changes
+                XmlConfigurator.ConfigureAndWatch(logRepository, new FileInfo(log4netConfigPath));
+
+                // Get the root logger and set its level based on debug flag
+                var hierarchy = (Hierarchy)logRepository;
+                if (Environment.GetCommandLineArgs().Contains("--debug"))
+                {
+                    hierarchy.Root.Level = hierarchy.LevelMap["DEBUG"];
+                }
+
+                var appender = hierarchy.Root.Appenders[0];
                 if (appender is RollingFileAppender fileAppender && fileAppender.File != logFilePath)
                 {
                     fileAppender.File = logFilePath;

--- a/ast-visual-studio-extension/CxWrapper/CxConstants.cs
+++ b/ast-visual-studio-extension/CxWrapper/CxConstants.cs
@@ -28,7 +28,7 @@
         public static string CLI_CANCEL_CMD => "cancel";
         public static string CLI_UTILS_CMD = "utils";
         public static string CLI_TENANT_CMD = "tenant";
-        public static string CLI_LEARN_MORE_CMD = "learn-more";
+        public static string CLI_LEARN_MORE_CMD => "learn-more";
 
 
         /** CLI FLAGS **/
@@ -68,30 +68,32 @@
         /** EXCEPTIONS **/
         public static string EXCEPTION_CREDENTIALS_NOT_SET => "Credentials are not set";
 
-        /** LOGGING **/
-        public static string LOG_RUNNING_AUTH_VALIDATE_CMD => "Initialized authentication validation command";
-        public static string LOG_RUNNING_ASCA_SCAN_CMD => "Running ASCA scan on file: {0}";
-        public static string LOG_RUNNING_ASCA_UPDATE_CMD => "Running ASCA update version";
-        public static string LOG_RUNNING_GET_RESULTS_CMD => "Retrieving the scan result for scan id {0}...";
-        public static string LOG_RUNNING_GET_PROJECTS_CMD => "Getting projects...";
-        public static string LOG_RUNNING_GET_BRANCHES_CMD => "Getting branches for project id {0}...";
-        public static string LOG_RUNNING_GET_SCANS_FOR_BRANCH_CMD => "Getting scans for branch {0}...";
-        public static string LOG_RUNNING_GET_SCANS_CMD => "Getting scans...";
-        public static string LOG_RUNNING_GET_SCAN_DETAILS_CMD => "Retrieving details for scan id {0}...";
-        public static string LOG_RUNNING_TRIAGE_UPDATE_CMD => "Executing 'triage update' command using the CLI...";
-        public static string LOG_RUNNING_TRIAGE_UPDATE_INFO_CMD => "Updating the similarityId {0} with state {1} and severity {2}...";
-        public static string LOG_RUNNING_TRIAGE_SHOW_CMD => "Executing 'triage show' command using the CLI...";
-        public static string LOG_RUNNING_TRIAGE_SHOW_INFO_CMD => "Fetching the list of predicates for projectId {0} , similarityId {1} and scan-type {2}...";
-        public static string LOG_RUNNING_TRIAGE_GET_STATES_CMD => "Executing 'triage get states' command using the CLI...";
-        public static string LOG_RUNNING_TRIAGE_GET_STATES_INFO_CMD => "Fetching the list of states...";
-        public static string LOG_RUNNING_CODEBASHING_CMD => "Fetching codebashing link...";
-        public static string LOG_RUNNING_SCAN_CREATE_CMD => "Executing 'scan create' command using the CLI...";
-        public static string LOG_RUNNING_SCAN_CANCEL_CMD => "Executing 'scan cancel' command using the CLI...";
-        public static string LOG_RUNNING_PROJECT_SHOW_CMD => "Retrieving details for project id: {0}...";
-        public static string LOG_RUNNING_TENANT_SETTINGS_CMD => "Getting tenant settings...";
-
         /** FILE EXTENSIONS **/
         public static string EXTENSION_JSON => ".json";
+
+        /** LOGGING MESSAGES **/
+        public static string LOG_CLI_COMMAND_EXECUTING => "Executing CLI command: {0}";
+        public static string LOG_CLI_COMMAND_COMPLETED => "CLI command completed with result length: {0}";
+        public static string LOG_CLI_COMMAND_ERROR => "CLI command failed: {0}";
+        public static string LOG_INITIALIZATION => "Initializing CxWrapper with configuration";
+        public static string LOG_RUNNING_ASCA_SCAN_CMD => "Running ASCA scan command for file: {0}";
+        public static string LOG_RUNNING_AUTH_VALIDATE_CMD => "Running auth validate command";
+        public static string LOG_RUNNING_GET_RESULTS_CMD => "Getting results for scan ID: {0}";
+        public static string LOG_RUNNING_GET_PROJECTS_CMD => "Getting projects list";
+        public static string LOG_RUNNING_PROJECT_SHOW_CMD => "Getting project details for ID: {0}";
+        public static string LOG_RUNNING_GET_BRANCHES_CMD => "Getting branches for project ID: {0}";
+        public static string LOG_RUNNING_GET_SCANS_FOR_BRANCH_CMD => "Getting scans for branch: {0}";
+        public static string LOG_RUNNING_GET_SCANS_CMD => "Getting all scans";
+        public static string LOG_RUNNING_GET_SCAN_DETAILS_CMD => "Getting scan details for ID: {0}";
+        public static string LOG_RUNNING_TRIAGE_UPDATE_CMD => "Running triage update command";
+        public static string LOG_RUNNING_TRIAGE_UPDATE_INFO_CMD => "Updating triage for similarity ID: {0}, state: {1}, severity: {2}";
+        public static string LOG_RUNNING_TRIAGE_SHOW_CMD => "Running triage show command";
+        public static string LOG_RUNNING_TRIAGE_SHOW_INFO_CMD => "Getting triage info for project ID: {0}, similarity ID: {1}, scan type: {2}";
+        public static string LOG_RUNNING_TRIAGE_GET_STATES_CMD => "Getting triage states";
+        public static string LOG_RUNNING_CODEBASHING_CMD => "Getting Codebashing links";
+        public static string LOG_RUNNING_TENANT_SETTINGS_CMD => "Getting tenant settings";
+        public static string LOG_RUNNING_SCAN_CREATE_CMD => "Creating new scan";
+        public static string LOG_RUNNING_SCAN_CANCEL_CMD => "Canceling scan";
 
         /** SCAN STATUS **/
         public static string SCAN_RUNNING => "running";

--- a/ast-visual-studio-extension/CxWrapper/CxWrapper.cs
+++ b/ast-visual-studio-extension/CxWrapper/CxWrapper.cs
@@ -21,11 +21,53 @@ namespace ast_visual_studio_extension.CxCLI
         {
             cxConfiguration.Validate();
             cxConfig = cxConfiguration;
-
-
             logger = LogManager.GetLogger(type);
+            logger.Info(CxConstants.LOG_INITIALIZATION);
+
+            // Subscribe to CLI output events
+            Execution.OnProcessCompleted += LogCliOutput;
         }
 
+        private void LogCliOutput(List<string> cliOutput)
+        {
+            foreach (var line in cliOutput)
+            {
+                logger.Info(line);
+            }
+        }
+
+        private string ExecuteCliCommand(List<string> arguments, Func<string, string> resultHandler)
+        {
+            try
+            {
+                string commandLine = $"cx.exe {string.Join(" ", arguments)}";
+                logger.Info($"Executing CLI command: {commandLine}");
+                var result = Execution.ExecuteCommand(WithConfigArguments(arguments), resultHandler);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                logger.Error($"CLI command failed: {ex.Message}", ex);
+                throw;
+            }
+        }
+
+        private string ExecuteCliCommand(List<string> arguments, string tempDir, string fileName)
+        {
+            try
+            {
+                string commandLine = $"cx.exe {string.Join(" ", arguments)}";
+                logger.Info(string.Format(CxConstants.LOG_CLI_COMMAND_EXECUTING, commandLine));
+                var result = Execution.ExecuteCommand(WithConfigArguments(arguments), tempDir, fileName);
+                logger.Info(string.Format(CxConstants.LOG_CLI_COMMAND_COMPLETED, result?.Length ?? 0));
+                return result;
+            }
+            catch (Exception ex)
+            {
+                logger.Error(string.Format(CxConstants.LOG_CLI_COMMAND_ERROR, ex.Message), ex);
+                throw;
+            }
+        }
 
         /// <summary>
         /// Scan file with ASCA
@@ -67,7 +109,7 @@ namespace ast_visual_studio_extension.CxCLI
 
             AppendAgentToArguments(agent, arguments);
 
-            string result = Execution.ExecuteCommand(WithConfigArguments(arguments), Execution.CheckValidJSONString);
+            string result = ExecuteCliCommand(arguments, Execution.CheckValidJSONString);
             return JsonConvert.DeserializeObject<CxAsca>(result);
         }
 
@@ -109,7 +151,7 @@ namespace ast_visual_studio_extension.CxCLI
                 CxConstants.CLI_VALIDATE_CMD
             };
 
-            return Execution.ExecuteCommand(WithConfigArguments(authValidateArguments), line => line);
+            return ExecuteCliCommand(authValidateArguments, line => line);
         }
 
         /// <summary>
@@ -184,7 +226,7 @@ namespace ast_visual_studio_extension.CxCLI
                     break;
             }
 
-            return Execution.ExecuteCommand(WithConfigArguments(resultsArguments), tempDir, fileName + extension);
+            return ExecuteCliCommand(resultsArguments, tempDir, fileName + extension);
         }
 
         /// <summary>

--- a/ast-visual-studio-extension/log4net.config
+++ b/ast-visual-studio-extension/log4net.config
@@ -13,9 +13,9 @@
 			</layout>
 		</appender>
 
-		<root>
-			<level value="INFO" />
-			<appender-ref ref="FileAppender" />
-		</root>
-	</log4net>
+        <root>
+            <level value="INFO" />
+            <appender-ref ref="FileAppender" />
+        </root>
+    </log4net>
 </configuration>


### PR DESCRIPTION
### Description
> Add CLI/Wrapper logs print to file , Logs will be print to next path 
C:\Users\<USERNAME>\AppData\Local\Temp\ast-visual-studio-extension\Logs
### References
> Add support for log to file --> https://checkmarx.atlassian.net/browse/AST-81186
### Testing
>Run relevant test to see that full logs printing to the file 
### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used