### PR TITLE
Add support to print logs to file AST-81186

### DIFF
--- a/ast-visual-studio-extension/CxWrapper/CxConstants.cs
+++ b/ast-visual-studio-extension/CxWrapper/CxConstants.cs
@@ -89,7 +89,9 @@
         public static string LOG_RUNNING_SCAN_CANCEL_CMD => "Executing 'scan cancel' command using the CLI...";
         public static string LOG_RUNNING_PROJECT_SHOW_CMD => "Retrieving details for project id: {0}...";
         public static string LOG_RUNNING_TENANT_SETTINGS_CMD => "Getting tenant settings...";
-
+        public static string LOG_CLI_COMMAND_EXECUTING => "Executing CLI command: {0}";
+        public static string LOG_CLI_COMMAND_COMPLETED => "CLI command completed with result length: {0}";
+        public static string LOG_CLI_COMMAND_ERROR => "CLI command failed: {0}";
         /** FILE EXTENSIONS **/
         public static string EXTENSION_JSON => ".json";
 


### PR DESCRIPTION


### Description

> Add CLI/Wrapper logs print to file , Logs will be print to next path  -->  C:\Users<USERNAME>\AppData\Local\Temp\ast-visual-studio-extension\Logs

### References

> Add support for log to file --> https://checkmarx.atlassian.net/browse/AST-81186

### Testing

> Run the relevant test to ensure that full logs are printed to the file

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used