### PR TITLE
If IdeScan is disabled still showing run scan icon (AST-116257)

### DIFF
--- a/ast-visual-studio-extension/CxWrapper/CxWrapper.cs
+++ b/ast-visual-studio-extension/CxWrapper/CxWrapper.cs
@@ -572,7 +572,9 @@ namespace ast_visual_studio_extension.CxCLI
         {
             List<TenantSetting> tenantSettings = TenantSettings();
 
-            return bool.Parse(tenantSettings.Find(s => s.Key.Equals(CxConstants.IDE_SCANS_KEY)).Value);
+            string value = tenantSettings.Find(s => s.Key.Equals(CxConstants.IDE_SCANS_KEY))?.Value;
+
+            return bool.TryParse(value, out bool result) && result;
         }
 
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Updated the `IdeScansEnabled` method to safely handle scenarios where the tenant setting value for `CxConstants.IDE_SCANS_KEY` is `null`, empty, or whitespace.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

## `bool.TryParse` Behavior Summary
 
| Input          | `bool.TryParse(input, out result)` | `result` Value | Notes                       |
|----------------|------------------------------------|----------------|-----------------------------|
| `null`         | `false`                            | `false`        | Parsing fails               |
| `""` (empty)   | `false`                            | `false`        | Parsing fails               |
| `" "` (space)  | `false`                            | `false`        | Parsing fails               |
| `"true"`       | `true`                             | `true`         | Parsing succeeds            |
| `"false"`      | `true`                             | `false`        | Parsing succeeds            |

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used