### PR TITLE
Plugin will display an error message when no valid projects are found in the open solution (AST-116483)

### DIFF
--- a/ast-visual-studio-extension/CxExtension/Utils/CxConstants.cs
+++ b/ast-visual-studio-extension/CxExtension/Utils/CxConstants.cs
@@ -93,7 +93,9 @@
         public static string PROJECT_AND_BRANCH_DO_NOT_MATCH => "The Git branch and files open in your workspace don't match the branch and project that were previously scanned in this Checkmarx project. Do you want to scan anyway?";
         public static string RUN_SCAN => "Run scan";
         public static string RUN_SCAN_ACTION => "RUN_SCAN_ACTION";
-
+        public static string NOT_A_VALID_PROJECT => "No.NET project files(.sln, .csproj, .vbproj, .fsproj, .vcxproj) found in directory";
+   
+       
         /** LEARN MORE AND REMEDIATION **/
         public static string CODE_SAMPLE_TITLE => "{0} using {1}";
         public static string NO_INFORMATION => "No information";


### PR DESCRIPTION

### Description

> If no ".sln" or ".csproj" files are found in the open solution, an error message will be displayed: "No valid project found in directory."

### References

> [Include supporting link to GitHub Issue/PR number](https://checkmarx.atlassian.net/browse/AST-116483)

### Testing

> Run a test with a valid project and verify that the scan is triggered and completes successfully. Then, run a test with an invalid project and confirm that the scan is not triggered and an error message is displayed.


<img width="1078" height="213" alt="image" src="https://github.com/user-attachments/assets/2b817d07-bfa2-42cf-9fa7-a0cc38118db6" />


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used