### PR TITLE
Remove top-level write-all permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Checkmarx One visual studio extension CI
 
 on: [ pull_request, workflow_dispatch ]
 
-permissions: write-all
+permissions: {}
 
 jobs:
   integration-tests:


### PR DESCRIPTION
There's only one job and it's already overriding the permissions to something finer grained.