### PR TITLE
chore: remove Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions" 
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Removes `.github/dependabot.yml` to disable Dependabot version updates.