### PR TITLE
Replace third-party VSIX action and use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,12 @@ jobs:
           git push origin "${tag}"
 
       - name: Increment VSIX version
-        id: vsix_version
-        uses: timheuer/vsix-version-stamp@9d38292e99e54046455bb68c6a2b5113d269a7d0 #v2
-        with:
-          manifest-file: ast-visual-studio-extension\source.extension.vsixmanifest
-          version-number: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          version="${{ inputs.tag }}"
+          manifest="ast-visual-studio-extension/source.extension.vsixmanifest"
+          sed -i "s/Version=\"[^\"]*\"/Version=\"$version\"/" "$manifest"
+          echo "Updated VSIX version to $version"
 
       - name: Restore NuGet packages
         run: msbuild -t:restore


### PR DESCRIPTION
## Summary
- Replace `timheuer/vsix-version-stamp` action with native bash/sed command (org policy restriction on third-party actions)
- Use `GITHUB_TOKEN` instead of `PERSONAL_ACCESS_TOKEN` for checkout step
- Improve sed regex pattern to preserve all manifest attributes (Language, Publisher, etc)

## Test plan
- Verify release workflow executes successfully with new VSIX version update method
- Confirm manifest file is properly updated with correct version and all attributes preserved
- Validate GITHUB_TOKEN has sufficient permissions for checkout and tag operations

🤖 Generated with Claude Code