### PR TITLE
fix: add contents:write permission to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ on:
 jobs:
   release:
     runs-on: cx-public-windows-x64
+    permissions:
+      contents: write
     outputs:
       CLI_VERSION: ${{ steps.extract_cli_version.outputs.CLI_VERSION }}
     steps:


### PR DESCRIPTION
## Summary
- `git push origin "${tag}"` was failing with 403 — `github-actions[bot]` denied write access
- Added `contents: write` permission scoped to the `release` job only (least-privilege)

## Root cause
The workflow had no `permissions` block, so the token defaulted to read-only for `contents`.

## Test plan
- [ ] Trigger a release workflow run and confirm the `Tag` step passes