### PR TITLE
fix: scope sed to Identity element when bumping VSIX version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           version="${{ inputs.tag }}"
           manifest="ast-visual-studio-extension/source.extension.vsixmanifest"
-          sed -i "s/Version=\"[^\"]*\"/Version=\"$version\"/" "$manifest"
+          sed -i "s/\(Identity[^>]*Version=\"\)[^\"]*\"/\1$version\"/" "$manifest"
           echo "Updated VSIX version to $version"
 
       - name: Restore NuGet packages


### PR DESCRIPTION
## Summary
- The broad `sed` pattern introduced in #335 was replacing **all** `Version="..."` attributes in the manifest, including the required `PackageManifest Version="2.0.0"`
- This caused `VSSDK1061: 'PackageManifest' element requires a Version equal to '2.0.0'` build failure
- Scoped the pattern to only match the `Identity` element's `Version` attribute

## Root cause
`s/Version="[^"]*"/Version="$version"/` matches every `Version=` in the file. The manifest has several:
- `PackageManifest Version="2.0.0"` ← must stay fixed
- `Identity ... Version="x.x"` ← this is the one to bump
- `InstallationTarget Version="[17.0, 18.0)"` ← must stay fixed