### PR TITLE
CISO-1497 - Switch Windows GHA runners to Windows 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ permissions: {}
 
 jobs:
   integration-tests:
-    runs-on: cx-public-windows-x64
+    runs-on: cx-public-windows-2022-x64
     permissions:
       contents: write
     steps:

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write  # for TimonVS/pr-labeler-action to add labels in PR
     runs-on: cx-public-ubuntu-x64
     steps:
-      - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af #v5
+      - uses: step-security/pr-labeler-action@ef1aaf0814c671e210aced271e5973b598049990 # v5.0.5
         with:
           configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   release:
-    runs-on: cx-public-windows-x64
+    runs-on: cx-public-windows-2022-x64
     permissions:
       contents: write
     outputs:


### PR DESCRIPTION
As of June 2026, the Windows 2025 runners have started shipping with Visual Studio 26. Per GitHub's docs, the only way to get VS 22 now is to use a Windows 2022 runner.